### PR TITLE
Configuration of supported operations

### DIFF
--- a/JCMathLib/src/opencrypto/jcmathlib/Base_Helper.java
+++ b/JCMathLib/src/opencrypto/jcmathlib/Base_Helper.java
@@ -7,13 +7,6 @@ package opencrypto.jcmathlib;
 public class Base_Helper {
     final ResourceManager rm;
 
-    /**
-     * Helper flag which signalizes that code is executed inside simulator
-     * (during tests). Is used to address simulator specific behaviour
-     * workaround if required.
-     */
-    public boolean bIsSimulator = false;
-
     public Base_Helper(ResourceManager resman) {
         rm = resman;
     }

--- a/JCMathLib/src/opencrypto/jcmathlib/ECConfig.java
+++ b/JCMathLib/src/opencrypto/jcmathlib/ECConfig.java
@@ -82,7 +82,6 @@ public class ECConfig {
     
     void reset() {
         bnh.FLAG_FAST_MULT_VIA_RSA = false;     
-        ech.FLAG_FAST_EC_MULT_VIA_KA = false;   
     }
     
     public void setECC256Config() {

--- a/JCMathLib/src/opencrypto/jcmathlib/ECExample.java
+++ b/JCMathLib/src/opencrypto/jcmathlib/ECExample.java
@@ -17,7 +17,7 @@ public class ECExample extends Applet {
     final static byte[] SCALAR_TEST_VALUE = {(byte) 0xE8, (byte) 0x05, (byte) 0xE8, (byte) 0x02, (byte) 0xBF, (byte) 0xEC, (byte) 0xEE, (byte) 0x91, (byte) 0x9B, (byte) 0x3D, (byte) 0x3B, (byte) 0xD8, (byte) 0x3C, (byte) 0x7B, (byte) 0x52, (byte) 0xA5, (byte) 0xD5, (byte) 0x35, (byte) 0x4C, (byte) 0x4C, (byte) 0x06, (byte) 0x89, (byte) 0x80, (byte) 0x54, (byte) 0xB9, (byte) 0x76, (byte) 0xFA, (byte) 0xB1, (byte) 0xD3, (byte) 0x5A, (byte) 0x10, (byte) 0x91};
 
     public ECExample() {
-        OperationSupport.getInstance().setCard(OperationSupport.SIMULATOR);
+        OperationSupport.getInstance().setCard(OperationSupport.SIMULATOR); // TODO set your card
         // Pre-allocate all helper structures
         ecc = new ECConfig((short) 256); 
         // Pre-allocate standard SecP256r1 curve and two EC points on this curve

--- a/JCMathLib/src/opencrypto/jcmathlib/ECExample.java
+++ b/JCMathLib/src/opencrypto/jcmathlib/ECExample.java
@@ -17,6 +17,7 @@ public class ECExample extends Applet {
     final static byte[] SCALAR_TEST_VALUE = {(byte) 0xE8, (byte) 0x05, (byte) 0xE8, (byte) 0x02, (byte) 0xBF, (byte) 0xEC, (byte) 0xEE, (byte) 0x91, (byte) 0x9B, (byte) 0x3D, (byte) 0x3B, (byte) 0xD8, (byte) 0x3C, (byte) 0x7B, (byte) 0x52, (byte) 0xA5, (byte) 0xD5, (byte) 0x35, (byte) 0x4C, (byte) 0x4C, (byte) 0x06, (byte) 0x89, (byte) 0x80, (byte) 0x54, (byte) 0xB9, (byte) 0x76, (byte) 0xFA, (byte) 0xB1, (byte) 0xD3, (byte) 0x5A, (byte) 0x10, (byte) 0x91};
 
     public ECExample() {
+        OperationSupport.getInstance().setCard(OperationSupport.SIMULATOR);
         // Pre-allocate all helper structures
         ecc = new ECConfig((short) 256); 
         // Pre-allocate standard SecP256r1 curve and two EC points on this curve

--- a/JCMathLib/src/opencrypto/jcmathlib/ECPoint.java
+++ b/JCMathLib/src/opencrypto/jcmathlib/ECPoint.java
@@ -346,7 +346,7 @@ public class ECPoint {
      * @param scalar value of scalar for multiplication
      */
     public void multiplication(Bignat scalar) {
-        if(ech.bIsSimulator && scalar.same_value(Bignat_Helper.TWO)) {
+        if(OperationSupport.getInstance().EC_SW_DOUBLE && scalar.same_value(Bignat_Helper.TWO)) {
             swDouble();
             return;
         }

--- a/JCMathLib/src/opencrypto/jcmathlib/ECPoint.java
+++ b/JCMathLib/src/opencrypto/jcmathlib/ECPoint.java
@@ -351,6 +351,10 @@ public class ECPoint {
      * @param scalar value of scalar for multiplication
      */
     public void multiplication(Bignat scalar) {
+        if(OperationSupport.getInstance().EC_SW_DOUBLE && scalar.same_value(Bignat_Helper.TWO)) {
+            swDouble();
+            return;
+        }
         if (ech.multKA.getAlgorithm() == ECPoint_Helper.ALG_EC_SVDP_DH_PLAIN_XY) {
             this.multiplication_xy(scalar);
         } else if (ech.multKA.getAlgorithm() == ECPoint_Helper.ALG_EC_SVDP_DH_PLAIN) {
@@ -397,11 +401,6 @@ public class ECPoint {
      * @param scalar value of scalar for multiplication
     */
     private void multiplication_x(Bignat scalar) {
-        if(OperationSupport.getInstance().EC_SW_DOUBLE && scalar.same_value(Bignat_Helper.TWO)) {
-            swDouble();
-            return;
-        }
-
         PM.check(PM.TRAP_ECPOINT_MULT_1);
         
         ech.fnc_multiplication_x.lock();

--- a/JCMathLib/src/opencrypto/jcmathlib/ECPoint.java
+++ b/JCMathLib/src/opencrypto/jcmathlib/ECPoint.java
@@ -219,6 +219,10 @@ public class ECPoint {
     public void add(ECPoint other) {
         PM.check(PM.TRAP_ECPOINT_ADD_1);
         boolean samePoint = this == other || isEqual(other);
+        if (samePoint && OperationSupport.getInstance().ECDH_XY) {
+            this.multiplication(Bignat_Helper.TWO);
+            return;
+        }
 
         ech.lock(ech.uncompressed_point_arr1);
         this.thePoint.getW(ech.uncompressed_point_arr1, (short) 0);
@@ -291,7 +295,7 @@ public class ECPoint {
         //x_r=lambda^2-x_p-x_q
         ech.fnc_add_x_r.lock();
         if (samePoint) {
-            short len = this.multiplication_x(Bignat_Helper.TWO, ech.fnc_add_x_r.as_byte_array(), (short) 0);
+            short len = this.multiplication_x_KA(Bignat_Helper.TWO, ech.fnc_add_x_r.as_byte_array(), (short) 0);
             ech.fnc_add_x_r.set_size(len); 
         } else {        
             ech.fnc_add_x_r.clone(ech.fnc_add_lambda);
@@ -341,11 +345,58 @@ public class ECPoint {
         multiplication(ech.fnc_multiplication_scalar);
         ech.fnc_multiplication_scalar.unlock();
     }
+
     /**
      * Multiply value of this point by provided scalar. Stores the result into this point.
      * @param scalar value of scalar for multiplication
      */
     public void multiplication(Bignat scalar) {
+        if (ech.multKA.getAlgorithm() == ECPoint_Helper.ALG_EC_SVDP_DH_PLAIN_XY) {
+            this.multiplication_xy(scalar);
+        } else if (ech.multKA.getAlgorithm() == ECPoint_Helper.ALG_EC_SVDP_DH_PLAIN) {
+            this.multiplication_x(scalar);
+        } else {
+            ISOException.throwIt(ReturnCodes.SW_OPERATION_NOT_SUPPORTED);
+        }
+    }
+
+    /**
+     * Multiply value of this point by provided scalar using XY key agreement. Stores the result into this point.
+     * @param scalar value of scalar for multiplication
+     */
+    public void multiplication_xy(Bignat scalar) {
+        ech.lock(ech.uncompressed_point_arr2);
+        short len = multiplication_xy_KA(scalar, ech.uncompressed_point_arr2, (short) 0);
+        this.setW(ech.uncompressed_point_arr2, (short) 0, len);
+        ech.unlock(ech.uncompressed_point_arr2);
+    }
+
+    /**
+     * Multiplies this point value with provided scalar and stores result into
+     * provided array. No modification of this point is performed.
+     * Native XY KeyAgreement engine is used.
+     *
+     * @param scalar value of scalar for multiplication
+     * @param outBuffer output array for resulting value
+     * @param outBufferOffset offset within output array
+     * @return length of resulting value (in bytes)
+     */
+    public short multiplication_xy_KA(Bignat scalar, byte[] outBuffer, short outBufferOffset) {
+        theCurve.disposable_priv.setS(scalar.as_byte_array(), (short) 0, scalar.length());
+        ech.multKA.init(theCurve.disposable_priv);
+
+        ech.lock(ech.uncompressed_point_arr1);
+        short len = this.getW(ech.uncompressed_point_arr1, (short) 0);
+        len = ech.multKA.generateSecret(ech.uncompressed_point_arr1, (short) 0, len, outBuffer, outBufferOffset);
+        ech.unlock(ech.uncompressed_point_arr1);
+        return len;
+    }
+
+    /**
+     * Multiply value of this point by provided scalar using X-only key agreement. Stores the result into this point.
+     * @param scalar value of scalar for multiplication
+    */
+    private void multiplication_x(Bignat scalar) {
         if(OperationSupport.getInstance().EC_SW_DOUBLE && scalar.same_value(Bignat_Helper.TWO)) {
             swDouble();
             return;
@@ -354,7 +405,7 @@ public class ECPoint {
         PM.check(PM.TRAP_ECPOINT_MULT_1);
         
         ech.fnc_multiplication_x.lock();
-        short len = this.multiplication_x(scalar, ech.fnc_multiplication_x.as_byte_array(), (short) 0);
+        short len = this.multiplication_x_KA(scalar, ech.fnc_multiplication_x.as_byte_array(), (short) 0);
         ech.fnc_multiplication_x.set_size(len); 
         PM.check(PM.TRAP_ECPOINT_MULT_2);
 
@@ -405,24 +456,11 @@ public class ECPoint {
         
         PM.check(PM.TRAP_ECPOINT_MULT_12);
     }
-
-    /**
-     * Multiplies this point value with provided scalar and stores result into provided array.
-     * No modification of this point is performed.
-     * @param scalar value of scalar for multiplication
-     * @param outBuffer output array for resulting value
-     * @param outBufferOffset offset within output array
-     * @return length of resulting value (in bytes)
-     */
-    public short multiplication_x(Bignat scalar, byte[] outBuffer, short outBufferOffset) {
-        return multiplication_x_KA(scalar, outBuffer, outBufferOffset);
-    }
-    
     
     /**
      * Multiplies this point value with provided scalar and stores result into
      * provided array. No modification of this point is performed.
-     * Native KeyAgreement engine is used.
+     * Native X-only KeyAgreement engine is used.
      *
      * @param scalar value of scalar for multiplication
      * @param outBuffer output array for resulting value
@@ -435,13 +473,13 @@ public class ECPoint {
         theCurve.disposable_priv.setS(scalar.as_byte_array(), (short) 0, scalar.length());
         PM.check(PM.TRAP_ECPOINT_MULT_X_2);
 
-        ech.fnc_multiplication_x_keyAgreement.init(theCurve.disposable_priv);
+        ech.multKA.init(theCurve.disposable_priv);
         PM.check(PM.TRAP_ECPOINT_MULT_X_3);
 
         ech.lock(ech.uncompressed_point_arr1);
         short len = this.getW(ech.uncompressed_point_arr1, (short) 0); 
         PM.check(PM.TRAP_ECPOINT_MULT_X_4);
-        len = ech.fnc_multiplication_x_keyAgreement.generateSecret(ech.uncompressed_point_arr1, (short) 0, len, outBuffer, outBufferOffset);
+        len = ech.multKA.generateSecret(ech.uncompressed_point_arr1, (short) 0, len, outBuffer, outBufferOffset);
         ech.unlock(ech.uncompressed_point_arr1);
         PM.check(PM.TRAP_ECPOINT_MULT_X_5);
         // Return always length of whole coordinate X instead of len - some real cards returns shorter value equal to SHA-1 output size although PLAIN results is filled into buffer (GD60) 

--- a/JCMathLib/src/opencrypto/jcmathlib/ECPoint_Helper.java
+++ b/JCMathLib/src/opencrypto/jcmathlib/ECPoint_Helper.java
@@ -82,10 +82,6 @@ public class ECPoint_Helper extends Base_Helper {
 
         fnc_negate_yBN = rm.helperEC_BN_C;
 
-        Bignat fnc_from_x_x;
-        Bignat fnc_from_x_y_sq;
-        Bignat fnc_from_x_y;
-
         fnc_is_y = rm.helperEC_BN_C;
 
         fnc_isEqual_hashArray = rm.helper_hashArray;

--- a/JCMathLib/src/opencrypto/jcmathlib/ECPoint_Helper.java
+++ b/JCMathLib/src/opencrypto/jcmathlib/ECPoint_Helper.java
@@ -10,11 +10,12 @@ import javacard.security.Signature;
  */
 public class ECPoint_Helper extends Base_Helper {
     // Selected constants missing from older JC API specs 
-    public static final byte KeyAgreement_ALG_EC_SVDP_DH_PLAIN = (byte) 3;
-    public static final byte KeyAgreement_ALG_EC_SVDP_DH_PLAIN_XY = (byte) 6;
-    public static final byte Signature_ALG_ECDSA_SHA_256 = (byte) 33;
+    public static final byte ALG_EC_SVDP_DH_PLAIN = (byte) 3;
+    public static final byte ALG_EC_SVDP_DH_PLAIN_XY = (byte) 6;
+    public static final byte ALG_ECDSA_SHA_256 = (byte) 33;
 
     byte[] uncompressed_point_arr1;
+    byte[] uncompressed_point_arr2;
     byte[] fnc_isEqual_hashArray;
     byte[] fnc_multiplication_resultArray;
 
@@ -41,17 +42,20 @@ public class ECPoint_Helper extends Base_Helper {
 
     Bignat fnc_is_y;
 
-    KeyAgreement fnc_multiplication_x_keyAgreement;
+    KeyAgreement multKA;
     Signature    fnc_SignVerifyECDSA_signEngine; 
     MessageDigest fnc_isEqual_hashEngine;
 
     public ECPoint_Helper(ResourceManager rm) {
         super(rm);
 
-        if(OperationSupport.getInstance().ECDH_X_ONLY) {
-            fnc_multiplication_x_keyAgreement = KeyAgreement.getInstance(KeyAgreement_ALG_EC_SVDP_DH_PLAIN, false);
+        if(OperationSupport.getInstance().ECDH_XY) {
+            multKA = KeyAgreement.getInstance(ALG_EC_SVDP_DH_PLAIN_XY, false);
         }
-        fnc_SignVerifyECDSA_signEngine = Signature.getInstance(Signature_ALG_ECDSA_SHA_256, false);
+        else if(OperationSupport.getInstance().ECDH_X_ONLY) {
+            multKA = KeyAgreement.getInstance(ALG_EC_SVDP_DH_PLAIN, false);
+        }
+        fnc_SignVerifyECDSA_signEngine = Signature.getInstance(ALG_ECDSA_SHA_256, false);
     }
 
     void initialize() {
@@ -88,5 +92,6 @@ public class ECPoint_Helper extends Base_Helper {
         fnc_isEqual_hashEngine = rm.hashEngine;
 
         uncompressed_point_arr1 = rm.helper_uncompressed_point_arr1;
+        uncompressed_point_arr2 = rm.helper_uncompressed_point_arr2;
     }
 }

--- a/JCMathLib/src/opencrypto/jcmathlib/ECPoint_Helper.java
+++ b/JCMathLib/src/opencrypto/jcmathlib/ECPoint_Helper.java
@@ -14,12 +14,6 @@ public class ECPoint_Helper extends Base_Helper {
     public static final byte KeyAgreement_ALG_EC_SVDP_DH_PLAIN_XY = (byte) 6;
     public static final byte Signature_ALG_ECDSA_SHA_256 = (byte) 33;
 
-    /**
-     * If true, fast multiplication of ECPoints via KeyAgreement can be used. Is
-     * set automatically after successful allocation of required engines
-     */
-    public boolean FLAG_FAST_EC_MULT_VIA_KA = false;
-
     byte[] uncompressed_point_arr1;
     byte[] fnc_isEqual_hashArray;
     byte[] fnc_multiplication_resultArray;
@@ -54,16 +48,10 @@ public class ECPoint_Helper extends Base_Helper {
     public ECPoint_Helper(ResourceManager rm) {
         super(rm);
 
-        FLAG_FAST_EC_MULT_VIA_KA = false; // set true only if succesfully allocated and tested below
-        try {
-            //fnc_multiplication_x_keyAgreement = KeyAgreement.getInstance(KeyAgreement.ALG_EC_SVDP_DHC, false);
-            //fnc_SignVerifyECDSA_signEngine = Signature.getInstance(Signature.ALG_ECDSA_SHA, false);
-            //fnc_multiplication_x_keyAgreement = KeyAgreement.getInstance(Consts.KeyAgreement_ALG_EC_SVDP_DH_PLAIN_XY, false);
+        if(OperationSupport.getInstance().ECDH_X_ONLY) {
             fnc_multiplication_x_keyAgreement = KeyAgreement.getInstance(KeyAgreement_ALG_EC_SVDP_DH_PLAIN, false);
-            fnc_SignVerifyECDSA_signEngine = Signature.getInstance(Signature_ALG_ECDSA_SHA_256, false);
-            FLAG_FAST_EC_MULT_VIA_KA = true;
-        } catch (Exception ignored) {
-        } // Discard any exception
+        }
+        fnc_SignVerifyECDSA_signEngine = Signature.getInstance(Signature_ALG_ECDSA_SHA_256, false);
     }
 
     void initialize() {

--- a/JCMathLib/src/opencrypto/jcmathlib/OCUnitTests.java
+++ b/JCMathLib/src/opencrypto/jcmathlib/OCUnitTests.java
@@ -94,6 +94,8 @@ public class OCUnitTests extends Applet {
     Integer         m_testINT2;
 
     public OCUnitTests() {
+        OperationSupport.getInstance().setCard(OperationSupport.SIMULATOR);
+
         m_memoryInfo = new short[(short) (7 * 3)]; // Contains RAM and EEPROM memory required for basic library objects 
         m_memoryInfoOffset = snapshotAvailableMemory((short) 1, m_memoryInfo, m_memoryInfoOffset);
         if (bTEST_256b_CURVE) {
@@ -371,8 +373,6 @@ public class OCUnitTests extends Applet {
             m_ecc.refreshAfterReset(); 
             m_ecc.unlockAll();
         }
-        if (m_ecc.bnh != null) {m_ecc.bnh.bIsSimulator = bIsSimulator; }
-        if (m_ecc.ech != null) {m_ecc.ech.bIsSimulator = bIsSimulator; }
     }
     void test_EC_SETCURVE_G(APDU apdu, short dataLen) {
         byte[] apdubuf = apdu.getBuffer();

--- a/JCMathLib/src/opencrypto/jcmathlib/OCUnitTests.java
+++ b/JCMathLib/src/opencrypto/jcmathlib/OCUnitTests.java
@@ -94,7 +94,7 @@ public class OCUnitTests extends Applet {
     Integer         m_testINT2;
 
     public OCUnitTests() {
-        OperationSupport.getInstance().setCard(OperationSupport.SIMULATOR);
+        OperationSupport.getInstance().setCard(OperationSupport.SIMULATOR); // TODO set your card
 
         m_memoryInfo = new short[(short) (7 * 3)]; // Contains RAM and EEPROM memory required for basic library objects 
         m_memoryInfoOffset = snapshotAvailableMemory((short) 1, m_memoryInfo, m_memoryInfoOffset);

--- a/JCMathLib/src/opencrypto/jcmathlib/ObjectAllocator.java
+++ b/JCMathLib/src/opencrypto/jcmathlib/ObjectAllocator.java
@@ -33,7 +33,8 @@ public class ObjectAllocator {
     public static final byte ECPH_helperEC_BN_E      = 12;
     public static final byte ECPH_helperEC_BN_F      = 13;
     public static final byte ECPH_uncompressed_point_arr1 = 14;
-    public static final byte ECPH_hashArray          = 15;
+    public static final byte ECPH_uncompressed_point_arr2 = 15;
+    public static final byte ECPH_hashArray          = 16;
     
     public static final short ALLOCATOR_TYPE_ARRAY_LENGTH = (short) (ECPH_hashArray + 1);
     
@@ -77,6 +78,7 @@ public class ObjectAllocator {
         ALLOCATOR_TYPE_ARRAY[ECPH_helperEC_BN_B] = JCSystem.MEMORY_TYPE_TRANSIENT_RESET;
         ALLOCATOR_TYPE_ARRAY[ECPH_helperEC_BN_C] = JCSystem.MEMORY_TYPE_TRANSIENT_RESET;
         ALLOCATOR_TYPE_ARRAY[ECPH_uncompressed_point_arr1] = JCSystem.MEMORY_TYPE_TRANSIENT_RESET;
+        ALLOCATOR_TYPE_ARRAY[ECPH_uncompressed_point_arr2] = JCSystem.MEMORY_TYPE_TRANSIENT_RESET;
     }   
 
     /**

--- a/JCMathLib/src/opencrypto/jcmathlib/OperationSupport.java
+++ b/JCMathLib/src/opencrypto/jcmathlib/OperationSupport.java
@@ -1,0 +1,54 @@
+package opencrypto.jcmathlib;
+
+/**
+ * OperationSupport class
+ * 
+ * @author Antonin Dufka
+ */
+public class OperationSupport {
+    private static OperationSupport instance;
+
+    public static final short SIMULATOR = 0x0000;
+    public static final short J2E145G = 0x0001;
+    public static final short J3H145 = 0x0002;
+    public static final short J3R180 = 0x0003;
+
+    public boolean RSA_MULT_TRICK = false;
+    public boolean RSA_MOD_EXP = true;
+    public boolean RSA_PREPEND_ZEROS = false;
+    public boolean RSA_KEY_REFRESH = false;
+    public boolean ECDH_X_ONLY = true;
+    public boolean EC_SW_DOUBLE = false;
+
+    private OperationSupport() {}
+
+    public static OperationSupport getInstance() {
+        if (OperationSupport.instance == null)
+            OperationSupport.instance = new OperationSupport();
+        return OperationSupport.instance;
+    }
+
+    public void setCard(short card_identifier) {
+        switch (card_identifier) {
+            case SIMULATOR:
+                RSA_MULT_TRICK = false;
+                RSA_PREPEND_ZEROS = true;
+                RSA_KEY_REFRESH = true;
+                EC_SW_DOUBLE = true;
+                break;
+            case J2E145G:
+                RSA_MULT_TRICK = true;
+                break;
+            case J3H145:
+                RSA_MULT_TRICK = true;
+                RSA_MOD_EXP = false;
+                break;
+            case J3R180:
+                RSA_MULT_TRICK = true;
+                RSA_MOD_EXP = false;
+                break;
+            default:
+                break;
+        }
+    }
+}

--- a/JCMathLib/src/opencrypto/jcmathlib/OperationSupport.java
+++ b/JCMathLib/src/opencrypto/jcmathlib/OperationSupport.java
@@ -17,6 +17,7 @@ public class OperationSupport {
     public boolean RSA_MOD_EXP = true;
     public boolean RSA_PREPEND_ZEROS = false;
     public boolean RSA_KEY_REFRESH = false;
+    public boolean ECDH_XY = false;
     public boolean ECDH_X_ONLY = true;
     public boolean EC_SW_DOUBLE = false;
 
@@ -34,6 +35,7 @@ public class OperationSupport {
                 RSA_MULT_TRICK = false;
                 RSA_PREPEND_ZEROS = true;
                 RSA_KEY_REFRESH = true;
+                // ECDH_XY = true;
                 EC_SW_DOUBLE = true;
                 break;
             case J2E145G:

--- a/JCMathLib/src/opencrypto/jcmathlib/OperationSupport.java
+++ b/JCMathLib/src/opencrypto/jcmathlib/OperationSupport.java
@@ -14,7 +14,7 @@ public class OperationSupport {
     public static final short J3R180 = 0x0003;
 
     public boolean RSA_MULT_TRICK = false;
-    public boolean RSA_MOD_EXP = true;
+    public boolean RSA_MOD_EXP = false;
     public boolean RSA_PREPEND_ZEROS = false;
     public boolean RSA_KEY_REFRESH = false;
     public boolean ECDH_XY = false;
@@ -33,6 +33,7 @@ public class OperationSupport {
         switch (card_identifier) {
             case SIMULATOR:
                 RSA_MULT_TRICK = false;
+                RSA_MOD_EXP = true;
                 RSA_PREPEND_ZEROS = true;
                 RSA_KEY_REFRESH = true;
                 // ECDH_XY = true;
@@ -40,6 +41,7 @@ public class OperationSupport {
                 break;
             case J2E145G:
                 RSA_MULT_TRICK = true;
+                RSA_MOD_EXP = true;
                 break;
             case J3H145:
                 RSA_MULT_TRICK = true;

--- a/JCMathLib/src/opencrypto/jcmathlib/ResourceManager.java
+++ b/JCMathLib/src/opencrypto/jcmathlib/ResourceManager.java
@@ -25,6 +25,7 @@ public class ResourceManager {
     byte[] helper_BN_array1 = null;
     byte[] helper_BN_array2 = null;
     byte[] helper_uncompressed_point_arr1 = null;
+    byte[] helper_uncompressed_point_arr2 = null;
     byte[] helper_hashArray = null;
     /**
      * Number of pre-allocated helper arrays
@@ -68,6 +69,8 @@ public class ResourceManager {
         locker.registerLock(helper_BN_array2);
         helper_uncompressed_point_arr1 = memAlloc.allocateByteArray((short) (MAX_POINT_SIZE + 1), memAlloc.getAllocatorType(ObjectAllocator.ECPH_uncompressed_point_arr1));
         locker.registerLock(helper_uncompressed_point_arr1);
+        helper_uncompressed_point_arr2 = memAlloc.allocateByteArray((short) (MAX_POINT_SIZE + 1), memAlloc.getAllocatorType(ObjectAllocator.ECPH_uncompressed_point_arr2));
+        locker.registerLock(helper_uncompressed_point_arr2);
         hashEngine = MessageDigest.getInstance(MessageDigest.ALG_SHA_256, false);
         helper_hashArray = memAlloc.allocateByteArray(hashEngine.getLength(), memAlloc.getAllocatorType(ObjectAllocator.ECPH_hashArray));
         locker.registerLock(helper_hashArray);

--- a/JCMathLib/src/opencrypto/jcmathlib/ReturnCodes.java
+++ b/JCMathLib/src/opencrypto/jcmathlib/ReturnCodes.java
@@ -19,7 +19,8 @@ public class ReturnCodes {
     public static final short SW_ECPOINT_INVALIDLENGTH          = (short) 0x700a;
     public static final short SW_ECPOINT_UNEXPECTED_KA_LEN      = (short) 0x700b;
     public static final short SW_ALLOCATOR_INVALIDOBJID         = (short) 0x700c;
-    
+    public static final short SW_OPERATION_NOT_SUPPORTED        = (short) 0x700d;
+
     
     // Specific codes to propagate exceptions cought 
     // lower byte of exception is value as defined in JCSDK/api_classic/constant-values.htm

--- a/JCMathLibTests/src/opencrypto/test/TestClient.java
+++ b/JCMathLibTests/src/opencrypto/test/TestClient.java
@@ -44,7 +44,7 @@ public class TestClient {
     public static boolean _TEST_EC = true;
     
     public static boolean _MEASURE_PERF = false;
-    public static boolean _MEASURE_PERF_ONLY_TARGET = true;
+    public static boolean _MEASURE_PERF_ONLY_TARGET = false;
     
 
 
@@ -92,7 +92,7 @@ public class TestClient {
                 //runCfg.testCardType = RunConfig.CARD_TYPE.JCARDSIMLOCAL;
                 //OpenCryptoFunctionalTests(runCfg);
                 //runCfg.failedTestsList.clear();
-                runCfg.testCardType = RunConfig.CARD_TYPE.PHYSICAL;
+                //runCfg.testCardType = RunConfig.CARD_TYPE.PHYSICAL;
                 OpenCryptoFunctionalTests(runCfg);
                 runCfg.failedTestsList.clear();
             }


### PR DESCRIPTION
This pull request adds OperationSupport class that allows configuring the set of allowed operations. By default, only basic operations are allowed. When a disabled operation should be used, the library throws the exception `SW_OPERATION_NOT_SUPPORTED`.

To use JCMathLib in a simulator, add the following line in the constructor of your applet.
```
OperationSupport.getInstance().setCard(OperationSupport.SIMULATOR);
```
There are also pre-configured sets of supported operations for some cards.

If you want to enable some operations that are not included in the default set, you can do it in the following way.
```
OperationSupport.getInstance().ECDH_XY = true;
```

The last example line enables ECPoint multiplication via `ALG_EC_SVDP_DH_PLAIN_XY` key agreement. This is a new feature included in this pull request that results in almost native performance of scalar multiplication on cards that support it.